### PR TITLE
refactor: initialize Kafka separately

### DIFF
--- a/kafka/sender.go
+++ b/kafka/sender.go
@@ -31,7 +31,7 @@ type StatusMessage struct {
 }
 
 // Initialize the Kafka reader and writer.
-func init() {
+func Initialize() {
 	KafkaReader = kafka.NewReader(kafka.ReaderConfig{
 		Brokers:                []string{config.KafkaUrl},
 		Topic: satelliteStatusTopic,

--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Initialize Kafka once we are sure that the configuration variables have values.
+	kafka.Initialize()
+
 	go ListenForAvailabilityStatusRequests()
 	http.HandleFunc("/health", HandleHealthEndpoint)
 	http.HandleFunc("/availability-check", HandleAvailabilityCheck)


### PR DESCRIPTION
Kafka is not being initialized properly in a Clowder environment. I am
suspecting this has to do with the "init" function from the files, which
immediately initializes the Kafka readers and writers without having
parsed the configuration.