### PR TITLE
fix: port not being properly picked up

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -42,7 +42,7 @@ func ParseConfig() error {
 			return fmt.Errorf("configuration missing: Kafka port")
 		}
 
-		KafkaUrl = fmt.Sprintf("%s:%d", hostname, port)
+		KafkaUrl = fmt.Sprintf("%s:%d", hostname, *port)
 	} else {
 		hostname := os.Getenv("QUEUE_HOST")
 		if hostname == "" {


### PR DESCRIPTION
Since the port is a pointer to an integer, the pointer must be
dereferenced first.