### PR TITLE
fix: wrong status code being returned for the health check

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func HandleHealthEndpoint(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 }
 
 // HandleAvailabilityCheck checks that the incoming request has the required "x-rh-identity" header, extracts the


### PR DESCRIPTION
Kubernetes is expecting a "200" from the health check instead of the
"204" the service is returning.