### PR TITLE
feature: load the sources config from Clowder

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -8,6 +8,8 @@ import (
 
 // defaultPort is the default port the service will run on.
 const defaultPort = "10000"
+// sourcesAppName is the way the "sources-api" is named in Clowder.
+const sourcesAppName = "sources-api"
 // sourcesV31Path is the path to the latest API version.
 const sourcesV31Path = "api/sources/v3.1"
 
@@ -28,6 +30,25 @@ var SourcesApiUrl string
 // taken from there. Otherwise, it just grabs the variables from the environment.
 func ParseConfig() error {
 	if v1.IsClowderEnabled() {
+		// Try to load the "sources" dependency.
+		var sourceDep *v1.DependencyEndpoint
+		for _, dep := range v1.LoadedConfig.Endpoints {
+			if dep.App == sourcesAppName {
+				sourceDep = &dep
+				break
+			}
+		}
+
+		// If the dependency was not found either the "sources-api" changed its name, or the dependency has not been
+		// specified on the "clowdapp.yaml" file.
+		if sourceDep == nil {
+			return fmt.Errorf(`could not find "%s" on Clowder's config`, sourcesAppName)
+		}
+
+		// Build the endpoints' paths.
+		SourcesApiHealthUrl = fmt.Sprintf("http://%s:%d/health", sourceDep.Hostname, sourceDep.Port)
+		SourcesApiUrl = fmt.Sprintf("%s:%d/%s", sourceDep.Hostname, sourceDep.Port, sourcesV31Path)
+
 		kafkaBroker := v1.LoadedConfig.Kafka.Brokers[0]
 
 		hostname := kafkaBroker.Hostname
@@ -44,6 +65,21 @@ func ParseConfig() error {
 
 		KafkaUrl = fmt.Sprintf("%s:%d", hostname, *port)
 	} else {
+		// Try to load the sources' backend's endpoint from the environment variables.
+		sourcesHost := os.Getenv("SOURCES_API_HOST")
+		if sourcesHost == "" {
+			return fmt.Errorf("configuration missing: Sources API host")
+		}
+
+		sourcesPort := os.Getenv("SOURCES_API_PORT")
+		if sourcesPort == "" || sourcesPort == "0" {
+			return fmt.Errorf("configuration missing: Sources API port")
+		}
+
+		// Build the back end's paths.
+		SourcesApiHealthUrl = fmt.Sprintf("%s:%s/health", sourcesHost, sourcesPort)
+		SourcesApiUrl = fmt.Sprintf("%s:%s/%s", sourcesHost, sourcesPort, sourcesV31Path)
+
 		hostname := os.Getenv("QUEUE_HOST")
 		if hostname == "" {
 			return fmt.Errorf("configuration missing: Kafka host")
@@ -55,21 +91,6 @@ func ParseConfig() error {
 		}
 
 		KafkaUrl = fmt.Sprintf("%s:%s", hostname, port)
-	}
-
-	{
-		sourcesHost := os.Getenv("SOURCES_API_HOST")
-		if sourcesHost == "" {
-			return fmt.Errorf("configuration missing: Sources API host")
-		}
-
-		sourcesPort := os.Getenv("SOURCES_API_PORT")
-		if sourcesPort == "" || sourcesPort == "0" {
-			return fmt.Errorf("configuration missing: Sources API port")
-		}
-
-		SourcesApiHealthUrl = fmt.Sprintf("%s:%s/health", sourcesHost, sourcesPort)
-		SourcesApiUrl = fmt.Sprintf("%s:%s/%s", sourcesHost, sourcesPort, sourcesV31Path)
 	}
 
 	port := os.Getenv("PORT")


### PR DESCRIPTION
Instead of having to pass the sources backend's details, we can let
Clowder do the work for us.