### PR TITLE
fix: missing protocol scheme on the sources API URL

### DIFF
--- a/config/parser.go
+++ b/config/parser.go
@@ -47,7 +47,7 @@ func ParseConfig() error {
 
 		// Build the endpoints' paths.
 		SourcesApiHealthUrl = fmt.Sprintf("http://%s:%d/health", sourceDep.Hostname, sourceDep.Port)
-		SourcesApiUrl = fmt.Sprintf("%s:%d/%s", sourceDep.Hostname, sourceDep.Port, sourcesV31Path)
+		SourcesApiUrl = fmt.Sprintf("http://%s:%d/%s", sourceDep.Hostname, sourceDep.Port, sourcesV31Path)
 
 		kafkaBroker := v1.LoadedConfig.Kafka.Brokers[0]
 


### PR DESCRIPTION
I forgot to include the HTTP protocol on the URL which made the fake
producer fail.