### PR TITLE
refactor: change the default port to 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ on the `10000` port by default.
 
 Once built with `go build`, be sure to provide the following environment variables when running the binary:
 
-* `PORT` — If set, it runs on the specified port. Example value: `10000`
+* `PORT` — If set, it runs on the specified port. Default value: `8000`
 * `QUEUE_HOST` — If Clowder is enabled it's not needed. Example value: `localhost`
 * `QUEUE_PORT` — If Clowder is enabled it's not needed. Example value: `9092`
 * `SOURCES_API_HOST` Example value: `http://localhost`
-* `SOURCES_API_PORT` Example value: `SOURCES_API_PORT=8000`
+* `SOURCES_API_PORT` Example value: `SOURCES_API_PORT=10000`
 
 It has two endpoints:
 

--- a/config/parser.go
+++ b/config/parser.go
@@ -7,7 +7,7 @@ import (
 )
 
 // defaultPort is the default port the service will run on.
-const defaultPort = "10000"
+const defaultPort = "8000"
 // sourcesAppName is the way the "sources-api" is named in Clowder.
 const sourcesAppName = "sources-api"
 // sourcesV31Path is the path to the latest API version.


### PR DESCRIPTION
Clowder automatically sets the service's port to 8000, so in order to
play nicely with that and not having to specify the custom port
environment variable for this binary, I'm changing the default port.